### PR TITLE
pam_sm_setcred seems required, even when not used

### DIFF
--- a/2man.c
+++ b/2man.c
@@ -72,3 +72,11 @@ PAM_EXTERN int pam_sm_authenticate(
     return PAM_SUCCESS;
   } 
 }
+
+#define UNUSED __attribute__ ((unused))
+PAM_EXTERN int
+pam_sm_setcred(pam_handle_t *pamh UNUSED, int flags UNUSED,
+               int argc UNUSED, const char **argv UNUSED)
+{
+        return PAM_IGNORE;
+}


### PR DESCRIPTION
It seems, that pam_sm_setcred is required, even when not used. Without this, pam_2man.so is not working with the following error:

sudo: PAM unable to resolve symbol: pam_sm_setcred
